### PR TITLE
AddAuthorAndManga Branch for tracking purposes

### DIFF
--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -1,3 +1,4 @@
 Wake up and slave~
 Manga Bleach added successfully to author Kubo Tite
+Successfully added author: Oda Eiichiro
 See you at the next slave session~

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -1,2 +1,3 @@
 add -a "Kubo Tite" -m "Bleach"
+add -a "Oda Eiichiro"
 bye


### PR DESCRIPTION
The actual implementation of the Add Author and Add Manga commands can be found in previously merged PR [here](https://github.com/AY2425S1-CS2113-T10-3/tp/pull/2). Against my better judgement I had accidentally deleted the branch on my fork that contributed to that PR. This PR/branch is merely created for tracking purposes and has been approved by Prof Akshay.