### PR TITLE
Update code sections authors for RepoSense

### DIFF
--- a/src/main/java/author/Author.java
+++ b/src/main/java/author/Author.java
@@ -80,6 +80,7 @@ public class Author {
         return Objects.hash(authorName);
     }
 
+    //@@author xenthm
     public void printMangaList() {
         mangaList.print();
     }

--- a/src/main/java/author/AuthorList.java
+++ b/src/main/java/author/AuthorList.java
@@ -8,6 +8,7 @@ public class AuthorList extends ArrayList<Author> {
         return contains(author);
     }
 
+    //@@author xenthm
     public boolean hasAuthor(String authorName) {
         assert !authorName.isEmpty() : "author name must not be empty";
         for (Author author : this) {
@@ -18,6 +19,7 @@ public class AuthorList extends ArrayList<Author> {
         return false;
     }
 
+    //@@author averageandyyy
     /**
      * Searches for existing author in {@code authorList} based on incoming author's
      * name
@@ -39,6 +41,7 @@ public class AuthorList extends ArrayList<Author> {
         return null;
     }
 
+    //@@author xenthm
     public Author getAuthor(String authorName) {
         assert !authorName.isEmpty() : "author name must not be empty";
         for (Author a : this) {

--- a/src/main/java/commands/ViewAuthorsCommand.java
+++ b/src/main/java/commands/ViewAuthorsCommand.java
@@ -5,6 +5,7 @@ import ui.Ui;
 
 import static constants.Command.VIEW_COMMAND;
 
+//@@author xenthm
 public class ViewAuthorsCommand extends Command {
     public ViewAuthorsCommand() {
         super(VIEW_COMMAND);

--- a/src/main/java/commands/ViewMangasCommand.java
+++ b/src/main/java/commands/ViewMangasCommand.java
@@ -7,6 +7,7 @@ import ui.Ui;
 
 import static constants.Command.VIEW_COMMAND;
 
+//@@author xenthm
 public class ViewMangasCommand extends Command {
     private String userInput;
 

--- a/src/main/java/manga/Manga.java
+++ b/src/main/java/manga/Manga.java
@@ -18,12 +18,14 @@ public class Manga {
         this.deadline = "None";
     }
 
+    //@@author xenthm
     public Manga(String mangaName, Author author, String deadline) {
         this.mangaName = mangaName;
         this.author = author;
         this.deadline = deadline;
     }
 
+    //@@author
     public String getMangaName() {
         return mangaName;
     }
@@ -64,7 +66,6 @@ public class Manga {
         return mangaName.equals(manga.getMangaName()) && author.equals(manga.getAuthor());
     }
 
-    //@@author averageandyyy
     @Override
     public int hashCode() {
         return Objects.hash(mangaName, author);

--- a/src/main/java/manga/MangaList.java
+++ b/src/main/java/manga/MangaList.java
@@ -2,6 +2,7 @@ package manga;
 
 import java.util.ArrayList;
 
+//@@author xenthm
 public class MangaList extends ArrayList<Manga> {
     public void print() {
         assert size() >= 0 : "MangaList.size() must be non-negative";

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -77,6 +77,7 @@ public class Parser {
         case CATALOG_COMMAND:
             // Returns either a Add or Delete command, which will either be Author or Manga related
             return processCatalogCommand(userInput);
+        //@@author xenthm
         case VIEW_COMMAND:
             if (isValidViewAuthorsCommand(userInput)) {
                 return new ViewAuthorsCommand();
@@ -85,6 +86,7 @@ public class Parser {
                 return new ViewMangasCommand(userInput);
             }
             throw new TantouException("Invalid view command provided!");
+        //@@author sarahchow03
         case DELETE_COMMAND:
             if (isValidDeadlineCommand(userInput)) {
                 return new DeleteDeadlineCommand(userInput);
@@ -321,6 +323,7 @@ public class Parser {
         }
     }
 
+    //@@author xenthm
     private boolean isValidViewMangaCommand(String userInput) throws TantouException {
         try {
             command = ownParser.parse(options, getUserInputAsList(userInput));
@@ -335,6 +338,7 @@ public class Parser {
         return !isValidViewMangaCommand(userInput);
     }
 
+    //@@author iaso1774
     private boolean isValidDeadlineCommand(String userInput) throws TantouException {
         try {
             command = ownParser.parse(options, getUserInputAsList(userInput));

--- a/src/main/java/tantou/Tantou.java
+++ b/src/main/java/tantou/Tantou.java
@@ -26,9 +26,7 @@ public class Tantou {
         this.authorList = authorList;
     }
 
-    //@@author averageandyyy
     public void run() {
-        //@@author xenthm
         AuthorList existingList = Storage.getInstance().readAuthorListFromDataFile();
         if (existingList != null) {
             setAuthorList(existingList);

--- a/src/test/java/author/AuthorListTest.java
+++ b/src/test/java/author/AuthorListTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+//@@author xenthm
 public class AuthorListTest {
     private final PrintStream standardOut = System.out;
     private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();

--- a/src/test/java/author/AuthorTest.java
+++ b/src/test/java/author/AuthorTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+//@@author xenthm
 public class AuthorTest {
     private final PrintStream standardOut = System.out;
     private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();

--- a/src/test/java/manga/MangaListTest.java
+++ b/src/test/java/manga/MangaListTest.java
@@ -8,6 +8,7 @@ import java.io.PrintStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+//@@author xenthm
 public class MangaListTest {
     private final PrintStream standardOut = System.out;
     private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();

--- a/src/test/java/parser/ParserTest.java
+++ b/src/test/java/parser/ParserTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
+//@@author xenthm
 public class ParserTest {
     private Parser parser;
 
@@ -30,6 +31,7 @@ public class ParserTest {
         parseInputAssertCommandType("bye", ByeCommand.class);
     }
 
+    //@@author xenthm
     @Test
     public void getUserCommand_viewAuthors_parsedCorrectly() {
         parseInputAssertCommandType("view", ViewAuthorsCommand.class);
@@ -40,6 +42,7 @@ public class ParserTest {
         parseInputAssertCommandType("view -a \"test\"", ViewMangasCommand.class);
     }
 
+    //@@author sarahchow03
     @Test
     public void getUserCommand_deleteAuthor_parsedCorrectly() {
         parseInputAssertCommandType("catalog -d -a \"test\"", DeleteAuthorCommand.class);
@@ -62,6 +65,7 @@ public class ParserTest {
         parseInputAssertCommandType("catalog -a \"test\" -m \"test\"", AddMangaCommand.class);
     }
 
+    //@@author xenthm
     private void parseInputAssertCommandType(String input, Class<? extends Command> expectedClass) {
         try {
             Command actual = parser.getUserCommand(input);


### PR DESCRIPTION
Based on [Week 10 tasks](https://nus-cs2113-ay2425s1.github.io/website/schedule/week10/project.html#4-ensure-the-code-is-reposense-compatible), `//@@author [github user]` should be used sparingly because its effects extend until another `//@@author [github user]` annotation is found or the end of the file is reached. 

Moving forward, we should strive to "close" our `//@@author [github user]` annotations such that we don't inadvertently claim more code than intended. 

Also, a lesson learnt is that syncing a updated upstream master with a local development branch (with conflicts there were resolved) messes with the native GitHub log system and incorrectly attributes all merged code as authored by the developer who synced. Try to limit this for now. 