### PR TITLE
Update ArgumentFinders to initialize outputString with userInput

### DIFF
--- a/src/main/java/parser/AuthorArgumentFinder.java
+++ b/src/main/java/parser/AuthorArgumentFinder.java
@@ -22,7 +22,7 @@ public class AuthorArgumentFinder extends ArgumentFinder {
     @Override
     public ArgumentResult getArgumentResult(String userInput) {
         String authorName = null;
-        String outputString = null;
+        String outputString = userInput;
         matcher = pattern.matcher(userInput);
 
         if (matcher.find()) {

--- a/src/main/java/parser/MangaArgumentFinder.java
+++ b/src/main/java/parser/MangaArgumentFinder.java
@@ -22,7 +22,7 @@ public class MangaArgumentFinder extends ArgumentFinder {
     @Override
     public ArgumentResult getArgumentResult(String userInput) {
         String mangaName = null;
-        String outputString = null;
+        String outputString = userInput;
         matcher = pattern.matcher(userInput);
 
         if (matcher.find()) {

--- a/src/main/java/parser/PriceArgumentFinder.java
+++ b/src/main/java/parser/PriceArgumentFinder.java
@@ -15,7 +15,7 @@ public class PriceArgumentFinder extends ArgumentFinder {
     @Override
     public ArgumentResult getArgumentResult(String userInput) throws TantouException {
         String price = null;
-        String outputString = null;
+        String outputString = userInput;
         matcher = pattern.matcher(userInput);
 
         if (matcher.find()) {

--- a/src/main/java/parser/QuantityArgumentFinder.java
+++ b/src/main/java/parser/QuantityArgumentFinder.java
@@ -14,7 +14,7 @@ public class QuantityArgumentFinder extends ArgumentFinder {
     @Override
     public ArgumentResult getArgumentResult(String userInput) throws TantouException {
         String quantity = null;
-        String outputString = null;
+        String outputString = userInput;
         matcher = pattern.matcher(userInput);
 
         if (matcher.find()) {


### PR DESCRIPTION
- Fix bug where matchers within ArgumentFinder would end up producing and working with null strings causing the program to crash
- userInput is always at least an empty string and this fix will ideally prevent the crash from taking place